### PR TITLE
[WIP] Added flag for custom scalar resources.

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -149,6 +149,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.MarkDeprecated("babysit-daemons", "Will be removed in a future version.")
 	fs.Int32Var(&s.MaxPods, "max-pods", s.MaxPods, "Number of Pods that can run on this Kubelet.")
 	fs.Int32Var(&s.NvidiaGPUs, "experimental-nvidia-gpus", s.NvidiaGPUs, "Number of NVIDIA GPU devices on this node. Only 0 (default) and 1 are currently supported.")
+	fs.StringVar(&s.CustomScalarResources, "custom-scalar-resources", s.CustomScalarResources, "Custom scalar resource names and quantities for this node to advertise as part of its capacity, as a comma-separated list of name=quantity pairs. For example: --custom-scalar-resources=bananasas=10,apples=100Mi. [default=none]")
 	fs.StringVar(&s.DockerExecHandlerName, "docker-exec-handler", s.DockerExecHandlerName, "Handler to use when executing a command in a container. Valid values are 'native' and 'nsenter'. Defaults to 'native'.")
 	fs.StringVar(&s.NonMasqueradeCIDR, "non-masquerade-cidr", s.NonMasqueradeCIDR, "Traffic to IPs outside this range will use IP masquerade.")
 	fs.StringVar(&s.PodCIDR, "pod-cidr", "", "The CIDR to use for pod IP addresses, only used in standalone mode.  In cluster mode, this is obtained from the master.")

--- a/cmd/kubelet/app/server_test.go
+++ b/cmd/kubelet/app/server_test.go
@@ -71,3 +71,55 @@ func TestValueOfAllocatableResources(t *testing.T) {
 		}
 	}
 }
+
+func TestValueOfCustomResources(t *testing.T) {
+	testCases := []struct {
+		flagValue     string
+		errorExpected bool
+		expectedLen   int
+		name          string
+	}{
+		{
+			flagValue:     "",
+			errorExpected: false,
+			expectedLen:   0,
+			name:          "empty flag value",
+		},
+		{
+			flagValue:     "apples=4Gi",
+			errorExpected: false,
+			expectedLen:   1,
+			name:          "valid single custom resource",
+		},
+		{
+			flagValue:     "apples=4Gi,bananas=100",
+			errorExpected: false,
+			expectedLen:   2,
+			name:          "valid custom resources",
+		},
+		{
+			flagValue:     "apples:4Gi,bananas:100",
+			errorExpected: true,
+			name:          "valid custom resources",
+		},
+	}
+
+	for _, test := range testCases {
+		parsedResources, err := parseCustomResources(test.flagValue)
+		if err != nil {
+			t.Logf("%s: error returned: %v", test.name, err)
+		}
+		if test.errorExpected {
+			if err == nil {
+				t.Errorf("%s: error expected", test.name)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("%s: unexpected error: %v", test.name, err)
+			}
+			if parsedResources == nil || len(parsedResources) != test.expectedLen {
+				t.Errorf("%s: unexpected map length (expected %d, found %d)", test.name, test.expectedLen, len(parsedResources))
+			}
+		}
+	}
+}

--- a/hack/verify-flags/known-flags.txt
+++ b/hack/verify-flags/known-flags.txt
@@ -90,6 +90,7 @@ cpu-percent
 create-external-load-balancer
 current-release-pr
 current-replicas
+custom-scalar-resources
 daemonset-lookup-cache-size
 default-container-cpu-limit
 default-container-mem-limit

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -317,6 +317,10 @@ type KubeletConfiguration struct {
 	MaxPods int32 `json:"maxPods"`
 	// nvidiaGPUs is the number of NVIDIA GPU devices on this node.
 	NvidiaGPUs int32 `json:"nvidiaGPUs"`
+	// Custom scalar resource names and quantities for this node to advertise as
+	// part of its capacity, as a comma-separated list of name=quantity pairs.
+	// For example: --custom-scalar-resources=bananas=10,apples=100Mi
+	CustomScalarResources string `json:"customScalarResources"`
 	// dockerExecHandlerName is the handler to use when executing a command
 	// in a container. Valid values are 'native' and 'nsenter'. Defaults to
 	// 'native'.

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -372,6 +372,10 @@ type KubeletConfiguration struct {
 	MaxPods int32 `json:"maxPods"`
 	// nvidiaGPUs is the number of NVIDIA GPU devices on this node.
 	NvidiaGPUs int32 `json:"nvidiaGPUs"`
+	// Custom scalar resource names and quantities for this node to advertise as
+	// part of its capacity, as a comma-separated list of name=quantity pairs.
+	// For example: --custom-scalar-resources=bananas=10,apples=100Mi
+	CustomScalarResources string `json:"customScalarResources"`
 	// dockerExecHandlerName is the handler to use when executing a command
 	// in a container. Valid values are 'native' and 'nsenter'. Defaults to
 	// 'native'.

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -255,6 +255,7 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_componentconfig_KubeletConfigu
 	out.BabysitDaemons = in.BabysitDaemons
 	out.MaxPods = in.MaxPods
 	out.NvidiaGPUs = in.NvidiaGPUs
+	out.CustomScalarResources = in.CustomScalarResources
 	out.DockerExecHandlerName = in.DockerExecHandlerName
 	out.PodCIDR = in.PodCIDR
 	out.ResolverConfig = in.ResolverConfig
@@ -419,6 +420,7 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 	out.BabysitDaemons = in.BabysitDaemons
 	out.MaxPods = in.MaxPods
 	out.NvidiaGPUs = in.NvidiaGPUs
+	out.CustomScalarResources = in.CustomScalarResources
 	out.DockerExecHandlerName = in.DockerExecHandlerName
 	out.PodCIDR = in.PodCIDR
 	out.ResolverConfig = in.ResolverConfig

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -274,6 +274,7 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 		out.BabysitDaemons = in.BabysitDaemons
 		out.MaxPods = in.MaxPods
 		out.NvidiaGPUs = in.NvidiaGPUs
+		out.CustomScalarResources = in.CustomScalarResources
 		out.DockerExecHandlerName = in.DockerExecHandlerName
 		out.PodCIDR = in.PodCIDR
 		out.ResolverConfig = in.ResolverConfig

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -269,6 +269,7 @@ func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface
 		out.BabysitDaemons = in.BabysitDaemons
 		out.MaxPods = in.MaxPods
 		out.NvidiaGPUs = in.NvidiaGPUs
+		out.CustomScalarResources = in.CustomScalarResources
 		out.DockerExecHandlerName = in.DockerExecHandlerName
 		out.PodCIDR = in.PodCIDR
 		out.ResolverConfig = in.ResolverConfig

--- a/pkg/kubelet/kubelet.go
+++ b/pkg/kubelet/kubelet.go
@@ -36,6 +36,7 @@ import (
 	cadvisorapi "github.com/google/cadvisor/info/v1"
 	"k8s.io/kubernetes/pkg/api"
 	utilpod "k8s.io/kubernetes/pkg/api/pod"
+	"k8s.io/kubernetes/pkg/api/resource"
 	"k8s.io/kubernetes/pkg/api/unversioned"
 	"k8s.io/kubernetes/pkg/api/validation"
 	"k8s.io/kubernetes/pkg/apis/componentconfig"
@@ -218,6 +219,7 @@ func NewMainKubelet(
 	maxPods int,
 	podsPerCore int,
 	nvidiaGPUs int,
+	customScalarResources map[string]resource.Quantity,
 	dockerExecHandler dockertools.ExecHandler,
 	resolverConfig string,
 	cpuCFSQuota bool,
@@ -346,6 +348,7 @@ func NewMainKubelet(
 		maxPods:                    maxPods,
 		podsPerCore:                podsPerCore,
 		nvidiaGPUs:                 nvidiaGPUs,
+		customScalarResources:      customScalarResources,
 		syncLoopMonitor:            atomic.Value{},
 		resolverConfig:             resolverConfig,
 		cpuCFSQuota:                cpuCFSQuota,
@@ -734,6 +737,9 @@ type Kubelet struct {
 
 	// Number of NVIDIA GPUs on this node
 	nvidiaGPUs int
+
+	// Custom scalar resources available on this node.
+	customScalarResources map[string]resource.Quantity
 
 	// Monitor Kubelet's sync loop
 	syncLoopMonitor atomic.Value

--- a/pkg/kubelet/kubelet_node_status.go
+++ b/pkg/kubelet/kubelet_node_status.go
@@ -386,6 +386,11 @@ func (kl *Kubelet) setNodeStatusMachineInfo(node *api.Node) {
 		node.Status.NodeInfo.BootID = info.BootID
 	}
 
+	// Add custom resources.
+	for rName, rCap := range kl.customScalarResources {
+		node.Status.Capacity[api.ResourceName(rName)] = rCap
+	}
+
 	// Set Allocatable.
 	node.Status.Allocatable = make(api.ResourceList)
 	for k, v := range node.Status.Capacity {


### PR DESCRIPTION
Summary of changes:
- Adds `--custom-scalar-resources` to options.
- Adds custom scalar resources to unversioned and versioned component
  config, Kubelet and Kubelet constructor.
- Adds custom resources from config to node status.
- Adds custom resource parsing to Kubelet server.

TODO(CD):
- [ ] Add tests for the above changes.

<hr />

Smoke testing done so far with this patch:

Starting without any extra flags:

```
[vagrant@localhost kubernetes]$ kubectl get nodes -o json | jq .items[].status.capacity
{
  "alpha.kubernetes.io/nvidia-gpu": "0",
  "cpu": "2",
  "memory": "8175808Ki",
  "pods": "110"
}
```

Modify the kubelet systemd unit to add the `--custom-scalar-resources` flag, defining two new custom resource types.

```
[vagrant@localhost kubernetes]$ vim /etc/systemd/system/k8s-kubelet.service 
[vagrant@localhost kubernetes]$ cat /etc/systemd/system/k8s-kubelet.service
[Unit]
Description=Kubernetes Kubelet
After=k8s-apiserver.service
Requires=k8s-apiserver.service

[Service]
TimeoutStartSec=0
Restart=always
ExecStart=/usr/local/bin/kubelet \
  --api-servers=127.0.0.1:8080 \
  --custom-scalar-resources=apples=10Mi,bananas=5

[Install]
WantedBy=multi-user.target
```

Restart the Kubelet.

```
[vagrant@localhost kubernetes]$ sudo systemctl daemon-reload
[vagrant@localhost kubernetes]$ sudo systemctl restart k8s-kubelet.service
```

Verify the Kubelet advertises the custom resources as part of the node status.

```
[vagrant@localhost kubernetes]$ kubectl get nodes -o json | jq .items[].status.capacity
{
  "alpha.kubernetes.io/nvidia-gpu": "0",
  "apples": "10Mi",
  "bananas": "5",
  "cpu": "2",
  "memory": "8175808Ki",
  "pods": "110"
}
```
