### PR TITLE
Added validation for opaque int resources.

### DIFF
--- a/pkg/api/validation/validation.go
+++ b/pkg/api/validation/validation.go
@@ -2652,6 +2652,10 @@ func ValidateNodeUpdate(node, oldNode *api.Node) field.ErrorList {
 	// 	allErrs = append(allErrs, field.Invalid("status", node.Status, "must be empty"))
 	// }
 
+	// Validate opaque integer resources.
+	allErrs = append(allErrs, ValidateOpaqueIntQuants(node.Status.Capacity, field.NewPath("status", "capacity"))...)
+	allErrs = append(allErrs, ValidateOpaqueIntQuants(node.Status.Allocatable, field.NewPath("status", "allocatable"))...)
+
 	// Validte no duplicate addresses in node status.
 	addresses := make(map[api.NodeAddress]bool)
 	for i, address := range node.Status.Addresses {
@@ -2685,6 +2689,18 @@ func ValidateNodeUpdate(node, oldNode *api.Node) field.ErrorList {
 		allErrs = append(allErrs, field.Forbidden(field.NewPath(""), "node updates may only change labels or capacity"))
 	}
 
+	return allErrs
+}
+
+// Validate that opaque integer resource quantities in a resource list are
+// indeed integers.
+func ValidateOpaqueIntQuants(rs api.ResourceList, fldPath *field.Path) field.ErrorList {
+	allErrs := field.ErrorList{}
+	for rName, rQuant := range rs {
+		if strings.HasPrefix(string(rName), api.ResourceOpaqueIntPrefix) && rQuant.MilliValue() != 1000*rQuant.Value() {
+			allErrs = append(allErrs, field.Invalid(fldPath, rQuant.String(), "fractional values are not allowed for opaque integer resources"))
+		}
+	}
 	return allErrs
 }
 
@@ -3054,6 +3070,9 @@ func ValidateResourceRequirements(requirements *api.ResourceRequirements, fldPat
 			allErrs = append(allErrs, validateBasicResource(quantity, fldPath.Key(string(resourceName)))...)
 		}
 	}
+	// Validate opaque integer resources.
+	allErrs = append(allErrs, ValidateOpaqueIntQuants(requirements.Requests, reqPath)...)
+	allErrs = append(allErrs, ValidateOpaqueIntQuants(requirements.Limits, limPath)...)
 	return allErrs
 }
 

--- a/pkg/api/validation/validation_test.go
+++ b/pkg/api/validation/validation_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package validation
 
 import (
+	"fmt"
 	"math/rand"
 	"reflect"
 	"strings"
@@ -3497,6 +3498,52 @@ func TestValidatePod(t *testing.T) {
 			},
 			Spec: validPodSpec,
 		},
+		{ // valid opaque integer resources for init container
+			ObjectMeta: api.ObjectMeta{Name: "valid-opaque-int", Namespace: "ns"},
+			Spec: api.PodSpec{
+				InitContainers: []api.Container{
+					{
+						Name:            "valid-opaque-int",
+						Image:           "image",
+						ImagePullPolicy: "IfNotPresent",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("10"),
+							},
+							Limits: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("20"),
+							},
+						},
+					},
+				},
+				Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
+				RestartPolicy: api.RestartPolicyAlways,
+				DNSPolicy:     api.DNSClusterFirst,
+			},
+		},
+		{ // valid opaque integer resources for regular container
+			ObjectMeta: api.ObjectMeta{Name: "valid-opaque-int", Namespace: "ns"},
+			Spec: api.PodSpec{
+				InitContainers: []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
+				Containers: []api.Container{
+					{
+						Name:            "valid-opaque-int",
+						Image:           "image",
+						ImagePullPolicy: "IfNotPresent",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("10"),
+							},
+							Limits: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("20"),
+							},
+						},
+					},
+				},
+				RestartPolicy: api.RestartPolicyAlways,
+				DNSPolicy:     api.DNSClusterFirst,
+			},
+		},
 	}
 	for _, pod := range successCases {
 		if errs := ValidatePod(&pod); len(errs) != 0 {
@@ -3945,6 +3992,112 @@ func TestValidatePod(t *testing.T) {
 				},
 			},
 			Spec: validPodSpec,
+		},
+		"invalid opaque integer resource requirement: request must be <= limit": {
+			ObjectMeta: api.ObjectMeta{Name: "123", Namespace: "ns"},
+			Spec: api.PodSpec{
+				Containers: []api.Container{
+					{
+						Name:            "invalid",
+						Image:           "image",
+						ImagePullPolicy: "IfNotPresent",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("2"),
+							},
+							Limits: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("1"),
+							},
+						},
+					},
+				},
+				RestartPolicy: api.RestartPolicyAlways,
+				DNSPolicy:     api.DNSClusterFirst,
+			},
+		},
+		"invalid fractional opaque integer resource in container request": {
+			ObjectMeta: api.ObjectMeta{Name: "123", Namespace: "ns"},
+			Spec: api.PodSpec{
+				Containers: []api.Container{
+					{
+						Name:            "invalid",
+						Image:           "image",
+						ImagePullPolicy: "IfNotPresent",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("500m"),
+							},
+						},
+					},
+				},
+				RestartPolicy: api.RestartPolicyAlways,
+				DNSPolicy:     api.DNSClusterFirst,
+			},
+		},
+		"invalid fractional opaque integer resource in init container request": {
+			ObjectMeta: api.ObjectMeta{Name: "123", Namespace: "ns"},
+			Spec: api.PodSpec{
+				InitContainers: []api.Container{
+					{
+						Name:            "invalid",
+						Image:           "image",
+						ImagePullPolicy: "IfNotPresent",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("500m"),
+							},
+						},
+					},
+				},
+				Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
+				RestartPolicy: api.RestartPolicyAlways,
+				DNSPolicy:     api.DNSClusterFirst,
+			},
+		},
+		"invalid fractional opaque integer resource in container limit": {
+			ObjectMeta: api.ObjectMeta{Name: "123", Namespace: "ns"},
+			Spec: api.PodSpec{
+				Containers: []api.Container{
+					{
+						Name:            "invalid",
+						Image:           "image",
+						ImagePullPolicy: "IfNotPresent",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("5"),
+							},
+							Limits: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("2.5"),
+							},
+						},
+					},
+				},
+				RestartPolicy: api.RestartPolicyAlways,
+				DNSPolicy:     api.DNSClusterFirst,
+			},
+		},
+		"invalid fractional opaque integer resource in init container limit": {
+			ObjectMeta: api.ObjectMeta{Name: "123", Namespace: "ns"},
+			Spec: api.PodSpec{
+				InitContainers: []api.Container{
+					{
+						Name:            "invalid",
+						Image:           "image",
+						ImagePullPolicy: "IfNotPresent",
+						Resources: api.ResourceRequirements{
+							Requests: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("5"),
+							},
+							Limits: api.ResourceList{
+								api.ResourceName(fmt.Sprintf("%sopaque-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("2.5"),
+							},
+						},
+					},
+				},
+				Containers:    []api.Container{{Name: "ctr", Image: "image", ImagePullPolicy: "IfNotPresent"}},
+				RestartPolicy: api.RestartPolicyAlways,
+				DNSPolicy:     api.DNSClusterFirst,
+			},
 		},
 	}
 	for k, v := range errorCases {
@@ -6120,6 +6273,60 @@ func TestValidateNodeUpdate(t *testing.T) {
 							        }
 							    ]
 							}`,
+				},
+			},
+		}, false},
+		{api.Node{
+			ObjectMeta: api.ObjectMeta{
+				Name: "valid-opaque-int-resources",
+			},
+		}, api.Node{
+			ObjectMeta: api.ObjectMeta{
+				Name: "valid-opaque-int-resources",
+			},
+			Status: api.NodeStatus{
+				Capacity: api.ResourceList{
+					api.ResourceName(api.ResourceCPU):                                                 resource.MustParse("10"),
+					api.ResourceName(api.ResourceMemory):                                              resource.MustParse("10G"),
+					api.ResourceName(fmt.Sprintf("%sopaque-resource-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("5"),
+					api.ResourceName(fmt.Sprintf("%sopaque-resource-B", api.ResourceOpaqueIntPrefix)): resource.MustParse("10"),
+				},
+			},
+		}, true},
+		{api.Node{
+			ObjectMeta: api.ObjectMeta{
+				Name: "invalid-fractional-opaque-int-capacity",
+			},
+		}, api.Node{
+			ObjectMeta: api.ObjectMeta{
+				Name: "invalid-fractional-opaque-int-capacity",
+			},
+			Status: api.NodeStatus{
+				Capacity: api.ResourceList{
+					api.ResourceName(api.ResourceCPU):                                                 resource.MustParse("10"),
+					api.ResourceName(api.ResourceMemory):                                              resource.MustParse("10G"),
+					api.ResourceName(fmt.Sprintf("%sopaque-resource-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("500m"),
+				},
+			},
+		}, false},
+		{api.Node{
+			ObjectMeta: api.ObjectMeta{
+				Name: "invalid-fractional-opaque-int-allocatable",
+			},
+		}, api.Node{
+			ObjectMeta: api.ObjectMeta{
+				Name: "invalid-fractional-opaque-int-allocatable",
+			},
+			Status: api.NodeStatus{
+				Capacity: api.ResourceList{
+					api.ResourceName(api.ResourceCPU):                                                 resource.MustParse("10"),
+					api.ResourceName(api.ResourceMemory):                                              resource.MustParse("10G"),
+					api.ResourceName(fmt.Sprintf("%sopaque-resource-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("5"),
+				},
+				Allocatable: api.ResourceList{
+					api.ResourceName(api.ResourceCPU):                                                 resource.MustParse("10"),
+					api.ResourceName(api.ResourceMemory):                                              resource.MustParse("10G"),
+					api.ResourceName(fmt.Sprintf("%sopaque-resource-A", api.ResourceOpaqueIntPrefix)): resource.MustParse("4.5"),
 				},
 			},
 		}, false},


### PR DESCRIPTION
- Added validation for opaque int resources.
- Ensure supplied opaque int quantities in node capacity, node allocatable,
  pod request and pod limit are integers.
- Added tests for new validation logic (node update and pod spec).

Testing: `make check WHAT=pkg/api/validation GOFLAGS="-v -run TestValidate"`
