### PR TITLE
Opaque isolation (external container lifecycle hooks)

### DIFF
--- a/cmd/kubelet/app/options/options.go
+++ b/cmd/kubelet/app/options/options.go
@@ -188,6 +188,7 @@ func (s *KubeletServer) AddFlags(fs *pflag.FlagSet) {
 	fs.Int32Var(&s.IPTablesMasqueradeBit, "iptables-masquerade-bit", s.IPTablesMasqueradeBit, "The bit of the fwmark space to mark packets for SNAT. Must be within the range [0, 31]. Please match this parameter with corresponding parameter in kube-proxy.")
 	fs.Int32Var(&s.IPTablesDropBit, "iptables-drop-bit", s.IPTablesDropBit, "The bit of the fwmark space to mark packets for dropping. Must be within the range [0, 31].")
 	fs.StringSliceVar(&s.AllowedUnsafeSysctls, "experimental-allowed-unsafe-sysctls", s.AllowedUnsafeSysctls, "Comma-separated whitelist of unsafe sysctls or unsafe sysctl patterns (ending in *). Use these at your own risk.")
+	fs.StringSliceVar(&s.ContainerHookPaths, "experimental-container-hook-paths", s.ContainerHookPaths, "Paths to Docker container lifecycle hook programs. Kubelet will invoke the hooks synchronously, in argument-order for each event.")
 
 	// Flags intended for testing, not recommended used in production environments.
 	fs.StringVar(&s.RemoteRuntimeEndpoint, "container-runtime-endpoint", s.RemoteRuntimeEndpoint, "The unix socket endpoint of remote runtime service. If not empty, this option will override --container-runtime. This is an experimental feature. Intended for testing only.")

--- a/examples/experimental/container-event-hooks/hook.py
+++ b/examples/experimental/container-event-hooks/hook.py
@@ -1,0 +1,49 @@
+#! /usr/bin/env python
+
+# Example container event lifecycle hook script.
+#
+# The Kubelet feeds this program on standard input a JSON-encoded event that
+# looks like:
+#
+# {
+#   "name": "PRE_START",
+#   "eventContext": {
+#     "pod": { ... },
+#     "container": { ... },
+#     "config": { ... }
+#   }
+# }
+#
+# The hook script must emit the (potentially modified) eventContext part, also
+# JSON-encoded, to standard output.
+#
+# {
+#   "pod": { ... },
+#   "container": { ... },
+#   "config": { ... }
+# }
+#
+# Bytes output to standard error will be included in the Kubelet logs.
+
+import json
+import sys
+
+# Log program name.
+print >> sys.stderr, sys.argv[0]
+
+event = json.loads(''.join(sys.stdin.readlines()))
+
+# Log receipt of event to standard error.
+print >> sys.stderr, "Received container lifecycle event: [%s]" % event['name']
+
+# Graffiti the docker container labels to show we were here.
+event['config']['Config']['Labels']['this-label-written-by'] = 'hook'
+
+# Emit the event context JSON to standard output.
+print json.dumps({
+    'pod': event['pod'],
+    'container': event['container'],
+    'config': event['config']
+})
+
+sys.exit(0)

--- a/pkg/apis/componentconfig/types.go
+++ b/pkg/apis/componentconfig/types.go
@@ -421,6 +421,9 @@ type KubeletConfiguration struct {
 	IPTablesDropBit int32 `json:"iptablesDropBit"`
 	// Whitelist of unsafe sysctls or sysctl patterns (ending in *).
 	AllowedUnsafeSysctls []string `json:"experimentalAllowedUnsafeSysctls,omitempty"`
+	// Paths to Docker container lifecycle hook programs. Kubelet will invoke the
+	// hooks synchronously, in argument-order for each event.
+	ContainerHookPaths []string `json:"containerHookPaths",omitempty"`
 }
 
 type KubeSchedulerConfiguration struct {

--- a/pkg/apis/componentconfig/v1alpha1/types.go
+++ b/pkg/apis/componentconfig/v1alpha1/types.go
@@ -477,4 +477,7 @@ type KubeletConfiguration struct {
 	// Whitelist of unsafe sysctls or sysctl patterns (ending in *). Use these at your own risk.
 	// Resource isolation might be lacking and pod might influence each other on the same node.
 	AllowedUnsafeSysctls []string `json:"allowedUnsafeSysctls,omitempty"`
+	// Paths to Docker container lifecycle hook programs. Kubelet will invoke the
+	// hooks synchronously, in argument-order for each event.
+	ContainerHookPaths []string `json:"containerHookPaths",omitempty"`
 }

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.conversion.go
@@ -333,6 +333,7 @@ func autoConvert_v1alpha1_KubeletConfiguration_To_componentconfig_KubeletConfigu
 		return err
 	}
 	out.AllowedUnsafeSysctls = in.AllowedUnsafeSysctls
+	out.ContainerHookPaths = in.ContainerHookPaths
 	return nil
 }
 
@@ -511,6 +512,7 @@ func autoConvert_componentconfig_KubeletConfiguration_To_v1alpha1_KubeletConfigu
 		return err
 	}
 	out.AllowedUnsafeSysctls = in.AllowedUnsafeSysctls
+	out.ContainerHookPaths = in.ContainerHookPaths
 	return nil
 }
 

--- a/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/v1alpha1/zz_generated.deepcopy.go
@@ -409,6 +409,13 @@ func DeepCopy_v1alpha1_KubeletConfiguration(in interface{}, out interface{}, c *
 		} else {
 			out.AllowedUnsafeSysctls = nil
 		}
+		if in.ContainerHookPaths != nil {
+			in, out := &in.ContainerHookPaths, &out.ContainerHookPaths
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		} else {
+			out.ContainerHookPaths = nil
+		}
 		return nil
 	}
 }

--- a/pkg/apis/componentconfig/zz_generated.deepcopy.go
+++ b/pkg/apis/componentconfig/zz_generated.deepcopy.go
@@ -344,6 +344,13 @@ func DeepCopy_componentconfig_KubeletConfiguration(in interface{}, out interface
 		} else {
 			out.AllowedUnsafeSysctls = nil
 		}
+		if in.ContainerHookPaths != nil {
+			in, out := &in.ContainerHookPaths, &out.ContainerHookPaths
+			*out = make([]string, len(*in))
+			copy(*out, *in)
+		} else {
+			out.ContainerHookPaths = nil
+		}
 		return nil
 	}
 }

--- a/pkg/kubelet/container/hook/hook.go
+++ b/pkg/kubelet/container/hook/hook.go
@@ -1,0 +1,164 @@
+package hook
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+
+	dockertypes "github.com/docker/engine-api/types"
+	"github.com/golang/glog"
+	"k8s.io/kubernetes/pkg/api"
+)
+
+// ContainerEventHooks implements container lifecycle callbacks to be invoked by
+// the runtime.
+type ContainerEventHooks interface {
+	Name() string
+	PreCreate(pod *api.Pod, container *api.Container, config *dockertypes.ContainerCreateConfig)
+	PreStart(pod *api.Pod, container *api.Container, config *dockertypes.ContainerCreateConfig)
+	PostStart(pod *api.Pod, container *api.Container, config *dockertypes.ContainerCreateConfig)
+	// PostStop(pod *api.Pod, container *api.Container)
+}
+
+type eventType string
+
+const (
+	preCreate eventType = "PRE_CREATE"
+	preStart  eventType = "PRE_START"
+	postStart eventType = "POST_START"
+	// postStop  eventType = "POST_STOP"
+)
+
+type eventInfo struct {
+	Name eventType `json:"name"`
+	eventContext
+}
+
+type eventContext struct {
+	Pod       *api.Pod                           `json:"pod"`
+	Container *api.Container                     `json:"container"`
+	Config    *dockertypes.ContainerCreateConfig `json:"config"`
+}
+
+// NewScriptContainerEventHooks returns a set of hooks that delegate to the
+// supplied script.
+func NewScriptContainerEventHooks(scriptPath string) ContainerEventHooks {
+	return scriptContainerEventHook{scriptPath}
+}
+
+// implements hook.ContainerEventHooks by executing an external program.
+// For each event callback, the program is invoked synchronously. The event
+// details are passed through standard input. The called program is expected
+// to make changes to the container configuration and emit a JSON-formatted
+// response on standard output.
+type scriptContainerEventHook struct{ scriptPath string }
+
+// The Kubelet feeds the script program on standard input a JSON-encoded event
+// that looks like:
+//
+// {
+//   "name": "PRE_CREATE",
+//   "eventContext": {
+//     "pod": { ... },
+//     "container": { ... },
+//     "config": { ... }
+//   }
+// }
+//
+// The hook script must emit (only) the potentially modified eventContext part,
+// also JSON-encoded, to standard output. Note that modified structures only
+// have meaning in response to the PRE_CREATE event.
+//
+// {
+//   "pod": { ... },
+//   "container": { ... },
+//   "config": { ... }
+// }
+//
+// Finally, bytes the hook program outputs to standard error will be included
+// in the Kubelet logs.
+func (h scriptContainerEventHook) callWithEvent(
+	eType eventType,
+	pod *api.Pod,
+	container *api.Container,
+	config *dockertypes.ContainerCreateConfig) (*eventContext, error) {
+
+	e := eventInfo{eType, eventContext{pod, container, config}}
+	data, err := json.Marshal(e)
+	if err != nil {
+		return nil, err
+	}
+	cmd := exec.Command(h.scriptPath)
+	cmd.Stdin = strings.NewReader(string(data))
+	cmd.Env = []string{} // Clean subprocess environment.
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	stderr, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, err
+	}
+	cmd.Start()
+
+	// Read standard error and log it, in a separate goroutine
+	// to avoid blocking writes to the stdout pipe.
+	go func() {
+		eout, err := ioutil.ReadAll(stderr)
+		if err != nil {
+			glog.Errorf("Unable to read stderr from hook script [%s]: %s", h.scriptPath, err.Error())
+		}
+		glog.Infof("Container event hook script [stderr]:\n%s", string(eout))
+	}()
+
+	// Parse standard out as eventContext JSON.
+	var resultContext *eventContext
+	if err := json.NewDecoder(stdout).Decode(&resultContext); err != nil {
+		return nil, err
+	}
+
+	// Log returned context.
+	resultJSON, err := json.Marshal(resultContext)
+	if err != nil {
+		return nil, err
+	}
+	glog.Infof("Container event hook script (%s) returned pod, container and config:\n%s", eType, resultJSON)
+
+	return resultContext, nil
+}
+
+func (h scriptContainerEventHook) Name() string {
+	return fmt.Sprintf("Script container event hook [%s]", h.scriptPath)
+}
+
+func (h scriptContainerEventHook) PreCreate(pod *api.Pod, container *api.Container, config *dockertypes.ContainerCreateConfig) {
+	ctx, err := h.callWithEvent(preCreate, pod, container, config)
+	if err != nil {
+		glog.Errorf("Failed to execute hook script [%s] for event %s: %s", h.scriptPath, preCreate, err.Error())
+		return
+	}
+
+	// Modify referenced pod, container and config.
+	*pod = *ctx.Pod
+	*container = *ctx.Container
+	*config = *ctx.Config
+}
+
+func (h scriptContainerEventHook) PreStart(pod *api.Pod, container *api.Container, config *dockertypes.ContainerCreateConfig) {
+	_, err := h.callWithEvent(preStart, pod, container, config)
+	if err != nil {
+		glog.Errorf("Failed to execute hook script [%s] for event %s: %s", h.scriptPath, preStart, err.Error())
+		return
+	}
+}
+
+func (h scriptContainerEventHook) PostStart(pod *api.Pod, container *api.Container, config *dockertypes.ContainerCreateConfig) {
+	_, err := h.callWithEvent(postStart, pod, container, config)
+	if err != nil {
+		glog.Errorf("Failed to execute hook script [%s] for event %s: %s", h.scriptPath, postStart, err.Error())
+		return
+	}
+}

--- a/pkg/kubelet/dockertools/fake_manager.go
+++ b/pkg/kubelet/dockertools/fake_manager.go
@@ -21,6 +21,7 @@ import (
 	"k8s.io/kubernetes/pkg/api"
 	"k8s.io/kubernetes/pkg/client/record"
 	kubecontainer "k8s.io/kubernetes/pkg/kubelet/container"
+	"k8s.io/kubernetes/pkg/kubelet/container/hook"
 	"k8s.io/kubernetes/pkg/kubelet/network"
 	proberesults "k8s.io/kubernetes/pkg/kubelet/prober/results"
 	kubetypes "k8s.io/kubernetes/pkg/kubelet/types"
@@ -51,7 +52,7 @@ func NewFakeDockerManager(
 	fakePodGetter := &fakePodGetter{}
 	dm := NewDockerManager(client, recorder, livenessManager, containerRefManager, fakePodGetter, machineInfo, podInfraContainerImage, qps,
 		burst, containerLogsDir, osInterface, networkPlugin, runtimeHelper, httpClient, &NativeExecHandler{},
-		fakeOOMAdjuster, fakeProcFs, false, imageBackOff, false, false, true, "/var/lib/kubelet/seccomp")
+		fakeOOMAdjuster, fakeProcFs, false, imageBackOff, false, false, true, "/var/lib/kubelet/seccomp", []hook.ContainerEventHooks{})
 	dm.dockerPuller = &FakeDockerPuller{}
 
 	// ttl of version cache is set to 0 so we always call version api directly in tests.


### PR DESCRIPTION
## Usage

Configure the Kubelet to run container lifecycle hook programs for PRE_CREATE, PRE_START, and POST_START events:

`--experimental-container-hook-paths=/path/to/my/hook.py`

Hook programs can be written in any language, as long as they can read and write JSON and communicate over stdout/stdin/stderr.

The Kubelet feeds the script program on standard input a JSON-encoded event that looks like:

``` json
{
  "name": "PRE_CREATE",
  "eventContext": {
    "pod": { ... },
    "container": { ... },
    "config": { ... }
  }
}
```

Where `pod` and `container` are Kubernetes API representations, and `config` is a Docker [`ContainerCreateConfig`](https://sourcegraph.com/github.com/docker/engine-api@4290f40c056686fcaa5c9caf02eac1dde9315adf/-/blob/types/configs.go#L13:6-13:27).

The hook script must emit (only) the potentially modified eventContext part, also JSON-encoded, to standard output. Note that modified structures only have meaning in response to the PRE_CREATE event.

``` json
{
  "pod": { ... },
  "container": { ... },
  "config": { ... }
}
```

Bytes the hook program outputs to standard error will be included in the Kubelet logs.
## Example

After installing the sample hook provided in this diff and running a single pod:

```
[vagrant@localhost ~]$ docker ps
CONTAINER ID        IMAGE                                      COMMAND                  CREATED              STATUS              PORTS               NAMES
473477adb6a9        nginx                                      "nginx -g 'daemon off"   About a minute ago   Up About a minute                       k8s_nginx.9179dbd3_nginx_default_bdd60a24-7bbb-11e6-bc97-525400659b2e_022ccd4d
ac1e3384afb5        gcr.io/google_containers/pause-amd64:3.0   "/pause"                 About a minute ago   Up About a minute                       k8s_POD.d8dbe16c_nginx_default_bdd60a24-7bbb-11e6-bc97-525400659b2e_337b8297
[vagrant@localhost ~]$ docker inspect 473 | jq .[0].Config.Labels
{
  "io.kubernetes.container.hash": "9179dbd3",
  "io.kubernetes.container.name": "nginx",
  "io.kubernetes.container.restartCount": "0",
  "io.kubernetes.container.terminationMessagePath": "/dev/termination-log",
  "io.kubernetes.pod.name": "nginx",
  "io.kubernetes.pod.namespace": "default",
  "io.kubernetes.pod.terminationGracePeriod": "30",
  "io.kubernetes.pod.uid": "bdd60a24-7bbb-11e6-bc97-525400659b2e",
  "this-label-written-by": "hook"
}
```
