### PR TITLE
Kuberuntime_container hotfix for nil pointer dereference

### DIFF
--- a/pkg/kubelet/cm/event_dispatcher.go
+++ b/pkg/kubelet/cm/event_dispatcher.go
@@ -280,16 +280,19 @@ func (ed *eventDispatcher) Unregister(ctx context.Context, request *lifecycle.Un
 	return &lifecycle.UnregisterReply{}, nil
 }
 
-func isEventReplyValid(reply *lifecycle.EventReply) (bool, error) {
-	if reply.Error != "" {
-		return false, fmt.Errorf("isolator has returned error: %s", reply.Error)
+func isEventReplyValid(reply *lifecycle.EventReply) error {
+	if reply == nil {
+		return fmt.Errorf("nil EvenReply has been recieved")
 	}
-	return true, nil
+	if reply.Error != "" {
+		return fmt.Errorf("isolator has returned error: %s", reply.Error)
+	}
+	return nil
 }
 
 // Updates the supplied resource config in-placed based on the isolation controls in the event reply.
 func UpdateResourceConfigWithReply(reply *lifecycle.EventReply, resources *ResourceConfig) error {
-	if ok, err := isEventReplyValid(reply); !ok {
+	if err := isEventReplyValid(reply); err != nil {
 		return err
 	}
 
@@ -313,7 +316,7 @@ func UpdateResourceConfigWithReply(reply *lifecycle.EventReply, resources *Resou
 // Updates the supplied container config in-place based on the isolation
 // controls in the event reply.
 func UpdateContainerConfigWithReply(reply *lifecycle.EventReply, config *runtime.ContainerConfig) error {
-	if ok, err := isEventReplyValid(reply); !ok {
+	if err := isEventReplyValid(reply); err != nil {
 		return err
 	}
 

--- a/pkg/kubelet/cm/event_dispatcher.go
+++ b/pkg/kubelet/cm/event_dispatcher.go
@@ -280,7 +280,7 @@ func (ed *eventDispatcher) Unregister(ctx context.Context, request *lifecycle.Un
 	return &lifecycle.UnregisterReply{}, nil
 }
 
-func eventReplyValidator(reply *lifecycle.EventReply) (bool, error) {
+func isEventReplyValid(reply *lifecycle.EventReply) (bool, error) {
 	if reply == nil {
 		glog.Info("eventDispatcherNoop has been detected - skipping container configuration update")
 		return false, nil
@@ -291,11 +291,9 @@ func eventReplyValidator(reply *lifecycle.EventReply) (bool, error) {
 	return true, nil
 }
 
-// Returns a pointer to an updated copy of the supplied resource config,
-// based on the isolation controls in the event reply. The original resource
-// config is not updated in-place.
-func ResourceConfigFromReply(reply *lifecycle.EventReply, resources *ResourceConfig) error {
-	if ok, err := eventReplyValidator(reply); !ok {
+// Updates the supplied resource config in-plased based on the isolation controls in the event reply.
+func UpdateResourceConfigWithReply(reply *lifecycle.EventReply, resources *ResourceConfig) error {
+	if ok, err := isEventReplyValid(reply); !ok {
 		return err
 	}
 
@@ -319,7 +317,7 @@ func ResourceConfigFromReply(reply *lifecycle.EventReply, resources *ResourceCon
 // Updates the supplied container config in-place based on the isolation
 // controls in the event reply.
 func UpdateContainerConfigWithReply(reply *lifecycle.EventReply, config *runtime.ContainerConfig) error {
-	if ok, err := eventReplyValidator(reply); !ok {
+	if ok, err := isEventReplyValid(reply); !ok {
 		return err
 	}
 

--- a/pkg/kubelet/cm/event_dispatcher.go
+++ b/pkg/kubelet/cm/event_dispatcher.go
@@ -281,17 +281,13 @@ func (ed *eventDispatcher) Unregister(ctx context.Context, request *lifecycle.Un
 }
 
 func isEventReplyValid(reply *lifecycle.EventReply) (bool, error) {
-	if reply == nil {
-		glog.Info("eventDispatcherNoop has been detected - skipping container configuration update")
-		return false, nil
-	}
 	if reply.Error != "" {
 		return false, fmt.Errorf("isolator has returned error: %s", reply.Error)
 	}
 	return true, nil
 }
 
-// Updates the supplied resource config in-plased based on the isolation controls in the event reply.
+// Updates the supplied resource config in-placed based on the isolation controls in the event reply.
 func UpdateResourceConfigWithReply(reply *lifecycle.EventReply, resources *ResourceConfig) error {
 	if ok, err := isEventReplyValid(reply); !ok {
 		return err
@@ -394,7 +390,7 @@ type eventDispatcherNoop struct {
 var _ EventDispatcher = &eventDispatcherNoop{}
 
 func (ed *eventDispatcherNoop) PreStartPod(pod *v1.Pod, cgroupPath string) (*lifecycle.EventReply, error) {
-	return nil, nil
+	return &lifecycle.EventReply{}, nil
 }
 
 func (ed *eventDispatcherNoop) PostStopPod(cgroupPath string) error {
@@ -402,7 +398,7 @@ func (ed *eventDispatcherNoop) PostStopPod(cgroupPath string) error {
 }
 
 func (ed *eventDispatcherNoop) PreStartContainer(podName, containerName string) (*lifecycle.EventReply, error) {
-	return nil, nil
+	return &lifecycle.EventReply{}, nil
 }
 
 func (ed *eventDispatcherNoop) PostStopContainer(podName, containerName string) error {
@@ -410,7 +406,7 @@ func (ed *eventDispatcherNoop) PostStopContainer(podName, containerName string) 
 }
 
 func (ed *eventDispatcherNoop) Start(socketAddress string) {
-
+	glog.Info("Using eventDispatcherNoop")
 }
 
 func (ed *eventDispatcherNoop) GetEventChannel() chan EventDispatcherEvent {

--- a/pkg/kubelet/cm/event_dispatcher_test.go
+++ b/pkg/kubelet/cm/event_dispatcher_test.go
@@ -658,7 +658,7 @@ func TestUpdateContainerConfigWithReply(t *testing.T) {
 			IsolationControls: testCase.isolationControls,
 		}
 
-		UpdateContainerConfigWithReply(reply, config)
+		config = UpdateContainerConfigWithReply(reply, config)
 		if !reflect.DeepEqual(config.Envs, testCase.expectedEnvs) {
 			t.Errorf("Obtained envs (%q) are not expected one (%q)",
 				config.Envs, testCase.expectedEnvs)

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -96,7 +96,7 @@ func (m *podContainerManagerImpl) EnsureExists(pod *v1.Pod) error {
 		}
 	}
 	// retrieve cgroupResources from replies from isolators and apply them on existing CgroupConfig
-	if err := ResourceConfigFromReply(reply, containerConfig.ResourceParameters); err != nil {
+	if err := UpdateResourceConfigWithReply(reply, containerConfig.ResourceParameters); err != nil {
 		return fmt.Errorf("failed to apply cgroupResources to existing CgroupConfig: %q", err.Error())
 	}
 

--- a/pkg/kubelet/cm/pod_container_manager_linux.go
+++ b/pkg/kubelet/cm/pod_container_manager_linux.go
@@ -96,8 +96,8 @@ func (m *podContainerManagerImpl) EnsureExists(pod *v1.Pod) error {
 		}
 	}
 	// retrieve cgroupResources from replies from isolators and apply them on existing CgroupConfig
-	if reply != nil {
-		containerConfig.ResourceParameters = ResourceConfigFromReply(reply, containerConfig.ResourceParameters)
+	if err := ResourceConfigFromReply(reply, containerConfig.ResourceParameters); err != nil {
+		return fmt.Errorf("failed to apply cgroupResources to existing CgroupConfig: %q", err.Error())
 	}
 
 	// Apply appropriate resource limits on the pod container

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -87,7 +87,7 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 	}
 
 	// Apply aggregated isolator responses to the container create config.
-	containermanager.UpdateContainerConfigWithReply(eventReply, containerConfig)
+	containerConfig = containermanager.UpdateContainerConfigWithReply(eventReply, containerConfig)
 
 	containerID, err := m.runtimeService.CreateContainer(podSandboxID, containerConfig, podSandboxConfig)
 	if err != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -86,14 +86,8 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 		return "", fmt.Errorf("failed to collect isolator responses for container %q: %v", containerConfig.Metadata.Name, err)
 	}
 
-	// In case of EventDispatcher is noop skip updating container config.
-	if eventReply != nil {
-		if eventReply.Error != "" {
-			return "", fmt.Errorf("isolator returned error: %s", eventReply.Error)
-		}
-		// Apply aggregated isolator responses to the container create config.
-		containermanager.UpdateContainerConfigWithReply(eventReply, containerConfig)
-	}
+	// Apply aggregated isolator responses to the container create config.
+	containermanager.UpdateContainerConfigWithReply(eventReply, containerConfig)
 
 	containerID, err := m.runtimeService.CreateContainer(podSandboxID, containerConfig, podSandboxConfig)
 	if err != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -85,11 +85,15 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 	if err != nil {
 		return "", fmt.Errorf("failed to collect isolator responses for container %q: %v", containerConfig.Metadata.Name, err)
 	}
-	if eventReply.Error != "" {
-		return "", fmt.Errorf("isolator returned error: %s", eventReply.Error)
+
+	// In case of EventDispatcher is noop skip updating container config.
+	if eventReply != nil {
+		if eventReply.Error != "" {
+			return "", fmt.Errorf("isolator returned error: %s", eventReply.Error)
+		}
+		// Apply aggregated isolator responses to the container create config.
+		containermanager.UpdateContainerConfigWithReply(eventReply, containerConfig)
 	}
-	// Apply aggregated isolator responses to the container create config.
-	containermanager.UpdateContainerConfigWithReply(eventReply, containerConfig)
 
 	containerID, err := m.runtimeService.CreateContainer(podSandboxID, containerConfig, podSandboxConfig)
 	if err != nil {

--- a/pkg/kubelet/kuberuntime/kuberuntime_container.go
+++ b/pkg/kubelet/kuberuntime/kuberuntime_container.go
@@ -87,7 +87,9 @@ func (m *kubeGenericRuntimeManager) startContainer(podSandboxID string, podSandb
 	}
 
 	// Apply aggregated isolator responses to the container create config.
-	containerConfig = containermanager.UpdateContainerConfigWithReply(eventReply, containerConfig)
+	if err := containermanager.UpdateContainerConfigWithReply(eventReply, containerConfig); err != nil {
+		return "", fmt.Errorf("failed to apply cgroupResources to existing containerConfig: %q", err.Error())
+	}
 
 	containerID, err := m.runtimeService.CreateContainer(podSandboxID, containerConfig, podSandboxConfig)
 	if err != nil {


### PR DESCRIPTION
In case of noop eventdispatcher, kuberuntime_container during pod
spawning. This hotfix won't update container configuration in case of
noop eventdispatcher will be detected.